### PR TITLE
Add Discord calls-to-action on home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,10 @@
 # Welcome to OpenDI 
 We're glad you're here!  The purpose of this website is to publish OpenDI standards, materials, and resources for you to use and contribute to.  
 
-Currently, standards are in draft / working draft format and may need significant additions, adjustments, or other [contributions](./How%20To%20Contribute.md) before they are ready for full use.
+Currently, standards are in draft / working draft format and may need significant additions, adjustments, or other contributions before they are ready for full use. 
+
+**We want your input!**  
+Please consider [contributing](./How%20To%20Contribute.md), and joining the [OpenDI Discord community](https://discord.gg/FtAX3JStJz).
 
 ## Who is OpenDI?
 
@@ -52,7 +55,13 @@ Describes an interchange format for how components of a DI system talk to anothe
 
 ## Contribution
 
-Want to join an exciting group of visionaries who are helping to create OpenDI?  Check out the [contribution guide](./How%20To%20Contribute.md) here.
+Want to join an exciting group of visionaries who are helping to create OpenDI?
+
+Check out the contribution guide!  
+[View Contribution Guide >>](./How%20To%20Contribute.md)  
+
+Join the OpenDI Discord community!  
+<iframe src="https://discord.com/widget?id=1208154608984129557&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
 
 ## Credits
 David Roberts, Lorien Pratt, Nadine Malcolm, Isaac Kellogg, <your name here!, [here's how](./How%20To%20Contribute.md)\>.


### PR DESCRIPTION
Added the same Discord iframe previously used [here](https://opendi.org/How%20To%20Contribute/#discord) to the contribution section on the main page.  
Reformatted contribution section to better fit the rest of the page contents, look more structured.

![Change 1 Contribution Section](https://github.com/opendi-org/landing-site/assets/162194260/df354e82-7f36-4239-ad6e-700a1bf29ddb)

Since this is down at the bottom of the page, added a less-space-consuming call to view contribution guide and join discord (with links) to the initial intro section as well.

![image](https://github.com/opendi-org/landing-site/assets/162194260/bd23b9cb-b604-49df-b86e-2602c9dd575e)

**NOTE:** Discord i-frame will not render in the GitHub Markdown preview. It will show as raw HTML. Once deployed, the i-frame will render properly.

Images are from a local test deployment, showing how these changes will appear once deployed.