### PR TITLE
Added config for Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "npm" #yarn
+  - package-ecosystem: "npm"
     schedule:
       interval: "weekly"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" #yarn
+    schedule:
+      interval: "weekly"
+    directory: "/"
+    target-branch: "dev"


### PR DESCRIPTION
Added `dependabot.yml` for dependabot security updates.
Configured dependabot to PR updates to `dev` instead of `main`.
Dependabot will check for updates weekly.

This improves the approval process for dependabot's auto-generated pull requests.