### PR TITLE
Org site refactor

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -13,7 +13,7 @@ assignees: ''
 Please submit your feedback to the most relevant repository:
 - [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
-- [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
+- [opendi-org/api-specification](https://github.com/opendi-org/api-specification) for feedback related to the OpenDI API Specification
 
 **Always use the Issue search feature to see if your report, request, or feedback already exists!**  
 If your issue already exists, add your voice to the comments section! Provide your unique perspective, additional info, etc.

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -11,7 +11,7 @@ assignees: ''
 (To save space, you may delete this section of the template before submitting your issue)
 
 Please submit your feedback to the most relevant repository:
-- [opendi-org/landing-site](https://github.com/opendi-org/landing-site) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
+- [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
 - [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
 

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -13,7 +13,7 @@ assignees: ''
 Please submit your feedback to the most relevant repository:
 - [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
-- [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
+- [opendi-org/api-specification](https://github.com/opendi-org/api-specification) for feedback related to the OpenDI API Specification
 
 **Always use the Issue search feature to see if your report, request, or feedback already exists!**  
 If your issue already exists, add your voice to the comments section! Provide your unique perspective, additional info, etc.

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -11,7 +11,7 @@ assignees: ''
 (To save space, you may delete this section of the template before submitting your issue)
 
 Please submit your feedback to the most relevant repository:
-- [opendi-org/landing-site](https://github.com/opendi-org/landing-site) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
+- [opendi-org/opendi-org.github.io](https://github.com/opendi-org/opendi-org.github.io) for general OpenDI feedback, or feedback related to the OpenDI homepage and related content
 - [opendi-org/roles-user-stories](https://github.com/opendi-org/roles-user-stories) for feedback related to the OpenDI roles and user stories
 - [opendi-org/json-schema](https://github.com/opendi-org/json-schema) for feedback related to the OpenDI JSON Schema
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Welcome! You're currently browsing source files for the OpenDI public website.
 
 ## Get started
 
-If you're looking to explore the standards or learn more about the project, [start on the website.](https://opendi-org.github.io/landing-site/)
+If you're looking to explore the standards or learn more about the project, [start on the website.](https://www.opendi.org/)
 
-If you'd like to contribute to OpenDI, check the [contribution guide.](https://opendi-org.github.io/landing-site/How%20To%20Contribute/)
+If you'd like to contribute to OpenDI, check the [contribution guide.](https://www.opendi.org/How%20To%20Contribute/)
 
 Want to engage in community discussion? Join the [OpenDI Discord server!](https://discord.gg/FtAX3JStJz).
 

--- a/docs/API Specification.md
+++ b/docs/API Specification.md
@@ -1,7 +1,0 @@
-# Watch this space
-This content is planned or under development, but is not yet ready for public comment.  
-Keep an eye on [the OpenDI Discord Server](https://discord.gg/FtAX3JStJz) for announcements related to this content.
-
-# What will this be?
-
-The OpenDI API Specification will define API endpoints that all OpenDI-compliant systems are expected to handle.

--- a/docs/How To Contribute.md
+++ b/docs/How To Contribute.md
@@ -20,9 +20,9 @@ Holds source content describing Roles for a DI team, and the user stories for ea
 
 [View Repo >>](https://github.com/opendi-org/roles-user-stories)
 
-### JSON Schema
+### API Specification
 
-Holds the OpenDI JSON Schema for Causal Decision Models, and source for the schema's documentation.
+Holds the OpenDI API Specification for interoperability among DI software systems and components.
 
 [View Repo >>](https://github.com/opendi-org/api-specification)
 

--- a/docs/How To Contribute.md
+++ b/docs/How To Contribute.md
@@ -12,7 +12,7 @@ This project is divided into 3 main repositories, holding different content:
 
 Holds the source content for the main OpenDI landing pages, including introductory and cross-document resources like this contribution guide.
 
-[View Repo >>](https://github.com/opendi-org/landing-site)
+[View Repo >>](https://github.com/opendi-org/opendi-org.github.io)
 
 ### Roles and User Stories
 
@@ -129,4 +129,4 @@ See [Browse Upcoming Changes](#browse-upcoming-changes).
 **Use the "Edit this page" link at the bottom of each page to access the GitHub web client and edit the source for the current page.**
 ![GitHub Edit Page link](./img/contribution-guide/GitHub-Edit-Link.png)  
 
-Looking for more technical information about project maintenance, deployment, and Docusuarus configuration? Check out the [maintainer guide](https://github.com/opendi-org/landing-site/tree/main/Maintainer%20Guide#maintainer-guide) on GitHub.
+Looking for more technical information about project maintenance, deployment, and Docusuarus configuration? Check out the [maintainer guide](https://github.com/opendi-org/opendi-org.github.io/tree/main/Maintainer%20Guide#maintainer-guide) on GitHub.

--- a/docs/How To Contribute.md
+++ b/docs/How To Contribute.md
@@ -24,7 +24,7 @@ Holds source content describing Roles for a DI team, and the user stories for ea
 
 Holds the OpenDI JSON Schema for Causal Decision Models, and source for the schema's documentation.
 
-[View Repo >>](https://github.com/opendi-org/json-schema)
+[View Repo >>](https://github.com/opendi-org/api-specification)
 
 ## Versions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,20 +38,15 @@ Describes a standardized language for talking about decision makers as they form
 
 [View Resource >>](http://opendi.org/roles-user-stories)
 
-### (Working Draft) JSON Schema
-Describes a format for files that contain Causal Decision Models (CDMs): the core representation of DI and the ecosystem.
-
-> This resource is in **working draft** state, meaning it is still under heavy development.  
-> While this resource may receive significant changes in a short time, comments and other input on its current state are still welcome!
-
-[View Resource >>](http://json-schema.opendi.org)
-
-### API Specification
+### (Working Draft) API Specification
 Describes an interchange format for how components of a DI system talk to another.  Just as you computer's keyboard can be made by one company, it's chips by another, and your mouse by a third, this API specification allows elements of a DI system to communicate in a standard language, thereby supporting a vibrant ecosystem of vendors, researchers, educators, and users.
 
-> This resource is in **pre-development**, meaning it is not yet ready for public comment.
+The associated JSON Schema describes a format for files that contain Causal Decision Models (CDMs): the core representation of DI and the ecosystem.
 
-[View Resource >> ](./API%20Specification.md)
+> This resource is in **working draft** state, meaning it is still under heavy development.  
+> While this resource may receive significant changes in a short time, comments and other input on its current state are welcome!
+
+[View Resource >>](http://opendi.org/api-specification)
 
 ## Contribution
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ OpenDI is a brand-new initiative, and this is reflected by our small set of init
 
 Describes a standardized language for talking about decision makers as they formalize &mdash; and build computer systems that help them to make &mdash; decisions.
 
-[View Resource >>](http://roles-user-stories.opendi.org)
+[View Resource >>](http://opendi.org/roles-user-stories)
 
 ### (Working Draft) JSON Schema
 Describes a format for files that contain Causal Decision Models (CDMs): the core representation of DI and the ecosystem.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,7 +110,7 @@ const config = {
               },
               {
                 label: 'Roles and User Stories',
-                href: 'http://roles-user-stories.opendi.org'
+                href: 'http://opendi.org/roles-user-stories'
               },
               {
                 label: 'JSON Schema',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,7 +113,7 @@ const config = {
                 href: 'http://opendi.org/roles-user-stories'
               },
               {
-                label: 'JSON Schema',
+                label: 'API Specification',
                 href: 'http://opendi.org/api-specification'
               },
             ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,12 +16,13 @@ const config = {
   url: 'https://opendi.org',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
+  // This will be our homepage, so it will go at the base path '/'
   baseUrl: '/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
   organizationName: 'opendi-org', // Usually your GitHub org/user name.
-  projectName: 'landing-site', // Usually your repo name.
+  projectName: 'landing-site',    // Leaving this as landing-site for now. I think this is more descriptive than opendi-org.github.io. From testing, this shouldn't impact deployment.
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -49,7 +50,7 @@ const config = {
             {
               return undefined;
             }
-            return "https://github.com/opendi-org/landing-site/tree/dev/" + versionDocsDirPath + "/" + docPath;
+            return "https://github.com/opendi-org/opendi-org.github.io/tree/dev/" + versionDocsDirPath + "/" + docPath;
           },
 
           routeBasePath: '/'
@@ -86,7 +87,7 @@ const config = {
           {
             'aria-label': 'GitHub Repo',
             className: 'navbar--github-link',
-            href: 'https://github.com/opendi-org/landing-site',
+            href: 'https://github.com/opendi-org/opendi-org.github.io',
             position: 'right',
           },
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -114,7 +114,7 @@ const config = {
               },
               {
                 label: 'JSON Schema',
-                href: 'http://json-schema.opendi.org'
+                href: 'http://opendi.org/api-specification'
               },
             ],
           },

--- a/sidebars.js
+++ b/sidebars.js
@@ -26,7 +26,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Roles and User Stories',
-          href: 'http://roles-user-stories.opendi.org'
+          href: 'http://opendi.org/roles-user-stories'
         },
         {
           type: 'link',

--- a/sidebars.js
+++ b/sidebars.js
@@ -30,13 +30,8 @@ const sidebars = {
         },
         {
           type: 'link',
-          label: '(Working Draft) JSON Schema',
-          href: 'http://json-schema.opendi.org'
-        },
-        {
-          type: 'doc',
-          label: 'API Specification',
-          id: 'API Specification'
+          label: '(Working Draft) API Specification',
+          href: 'http://opendi.org/api-specification'
         },
       ]
     },

--- a/versioned_docs/version-Live/API Specification.md
+++ b/versioned_docs/version-Live/API Specification.md
@@ -1,7 +1,0 @@
-# Watch this space
-This content is planned or under development, but is not yet ready for public comment.  
-Keep an eye on [the OpenDI Discord Server](https://discord.gg/FtAX3JStJz) for announcements related to this content.
-
-# What will this be?
-
-The OpenDI API Specification will define API endpoints that all OpenDI-compliant systems are expected to handle.

--- a/versioned_docs/version-Live/How To Contribute.md
+++ b/versioned_docs/version-Live/How To Contribute.md
@@ -20,9 +20,9 @@ Holds source content describing Roles for a DI team, and the user stories for ea
 
 [View Repo >>](https://github.com/opendi-org/roles-user-stories)
 
-### JSON Schema
+### API Specification
 
-Holds the OpenDI JSON Schema for Causal Decision Models, and source for the schema's documentation.
+Holds the OpenDI API Specification for interoperability among DI software systems and components.
 
 [View Repo >>](https://github.com/opendi-org/api-specification)
 

--- a/versioned_docs/version-Live/How To Contribute.md
+++ b/versioned_docs/version-Live/How To Contribute.md
@@ -12,7 +12,7 @@ This project is divided into 3 main repositories, holding different content:
 
 Holds the source content for the main OpenDI landing pages, including introductory and cross-document resources like this contribution guide.
 
-[View Repo >>](https://github.com/opendi-org/landing-site)
+[View Repo >>](https://github.com/opendi-org/opendi-org.github.io)
 
 ### Roles and User Stories
 
@@ -129,4 +129,4 @@ See [Browse Upcoming Changes](#browse-upcoming-changes).
 **Use the "Edit this page" link at the bottom of each page to access the GitHub web client and edit the source for the current page.**
 ![GitHub Edit Page link](./img/contribution-guide/GitHub-Edit-Link.png)  
 
-Looking for more technical information about project maintenance, deployment, and Docusuarus configuration? Check out the [maintainer guide](https://github.com/opendi-org/landing-site/tree/main/Maintainer%20Guide#maintainer-guide) on GitHub.
+Looking for more technical information about project maintenance, deployment, and Docusuarus configuration? Check out the [maintainer guide](https://github.com/opendi-org/opendi-org.github.io/tree/main/Maintainer%20Guide#maintainer-guide) on GitHub.

--- a/versioned_docs/version-Live/How To Contribute.md
+++ b/versioned_docs/version-Live/How To Contribute.md
@@ -24,7 +24,7 @@ Holds source content describing Roles for a DI team, and the user stories for ea
 
 Holds the OpenDI JSON Schema for Causal Decision Models, and source for the schema's documentation.
 
-[View Repo >>](https://github.com/opendi-org/json-schema)
+[View Repo >>](https://github.com/opendi-org/api-specification)
 
 ## Versions
 

--- a/versioned_docs/version-Live/index.md
+++ b/versioned_docs/version-Live/index.md
@@ -38,20 +38,15 @@ Describes a standardized language for talking about decision makers as they form
 
 [View Resource >>](http://opendi.org/roles-user-stories)
 
-### (Working Draft) JSON Schema
-Describes a format for files that contain Causal Decision Models (CDMs): the core representation of DI and the ecosystem.
-
-> This resource is in **working draft** state, meaning it is still under heavy development.  
-> While this resource may receive significant changes in a short time, comments and other input on its current state are still welcome!
-
-[View Resource >>](http://json-schema.opendi.org)
-
-### API Specification
+### (Working Draft) API Specification
 Describes an interchange format for how components of a DI system talk to another.  Just as you computer's keyboard can be made by one company, it's chips by another, and your mouse by a third, this API specification allows elements of a DI system to communicate in a standard language, thereby supporting a vibrant ecosystem of vendors, researchers, educators, and users.
 
-> This resource is in **pre-development**, meaning it is not yet ready for public comment.
+The associated JSON Schema describes a format for files that contain Causal Decision Models (CDMs): the core representation of DI and the ecosystem.
 
-[View Resource >> ](./API%20Specification.md)
+> This resource is in **working draft** state, meaning it is still under heavy development.  
+> While this resource may receive significant changes in a short time, comments and other input on its current state are welcome!
+
+[View Resource >>](http://opendi.org/api-specification)
 
 ## Contribution
 

--- a/versioned_docs/version-Live/index.md
+++ b/versioned_docs/version-Live/index.md
@@ -36,7 +36,7 @@ OpenDI is a brand-new initiative, and this is reflected by our small set of init
 
 Describes a standardized language for talking about decision makers as they formalize &mdash; and build computer systems that help them to make &mdash; decisions.
 
-[View Resource >>](http://roles-user-stories.opendi.org)
+[View Resource >>](http://opendi.org/roles-user-stories)
 
 ### (Working Draft) JSON Schema
 Describes a format for files that contain Causal Decision Models (CDMs): the core representation of DI and the ecosystem.

--- a/versioned_sidebars/version-Live-sidebars.json
+++ b/versioned_sidebars/version-Live-sidebars.json
@@ -22,7 +22,7 @@
         {
           "type": "link",
           "label": "Roles and User Stories",
-          "href": "http://roles-user-stories.opendi.org"
+          "href": "http://opendi.org/roles-user-stories"
         },
         {
           "type": "link",

--- a/versioned_sidebars/version-Live-sidebars.json
+++ b/versioned_sidebars/version-Live-sidebars.json
@@ -26,13 +26,8 @@
         },
         {
           "type": "link",
-          "label": "(Working Draft) JSON Schema",
-          "href": "http://json-schema.opendi.org"
-        },
-        {
-          "type": "doc",
-          "label": "API Specification",
-          "id": "API Specification"
+          "label": "(Working Draft) API Specification",
+          "href": "http://opendi.org/api-specification"
         }
       ]
     },


### PR DESCRIPTION
# Summary

Made changes to prepare to rename this landing-site repo to opendi-org.github.io, so that it forms the base of the organization's GitHub Pages site.  
This will allow us to remove the custom subdomains from the Roles and User Stories site and what is currently the JSON Schema site.  
Those sites will instead be hosted at `opendi.org/<repo-name>/`.

This Landing Site repo is currently planned to be renamed to `opendi-org.github.io`.

**Note:** Once merged, these changes may break some links. This will be temporary. The broken links will work once all related repositories have been similarly updated, and after the planned renaming and settings changes (see below) have been implemented.

# Details

Updated any GitHub repo links to point to a repo called opendi-org.github.io instead of landing-site.

Updated links opendi.org/roles-user-stories instead of roles-user-stories.opendi.org

Updated links to point to opendi.org/api-specification instead of json-schema.opendi.org
Updated wording/formatting on index.md and sidebars.js (and versioned counterparts) to reflect the incorporation of the JSON Schema into the API spec. (These had previously been considered separate resources).

Updated GitHub links/references to json-schema repo, to now refer to api-specification repo.

Removed the old placeholder page for the API Specification. This was used as a "coming soon" page for the API Specification, which will exist shortly.
Links to this old page now point to `opendi.org/api-specification` instead.
Once the API Specification site draft is accepted and merged into `main`, this link will not need updating. In the interim it will point to the JSON Schema site.

# Planned renaming and settings changes

Once all changes are merged to `main`:
- This repo will be renamed from `landing-site` to `opendi-org.github.io`. This will be changed from the [general settings](https://github.com/opendi-org/landing-site/settings) page of the repo. This will cause all other repositories to (by default) host their GitHub Pages websites in subdirectories of the custom domain supplied in the [Pages settings](https://github.com/opendi-org/landing-site/settings/pages) of this repo. That domain will remain `opendi.org`. The final URL for this landing site will be `https://opendi.org`.