### PR TITLE
Homepage: Ambassadors, intro video + content pass

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,24 +10,27 @@ Please consider [contributing](./How%20To%20Contribute.md), and joining the [Ope
 
 We are a decentralized group of entrepreneurs, executives, researchers, government leaders, and educators working to build an inclusive Decision Intelligence (DI) ecosystem dedicated to driving technological innovation, collaboration, and advancements in human decision making. Our goal is simple: *to break down the barriers that hinder progress and create a more open and integrated platform for Decision Intelligence technologies and services.*
 
-## Why
+<p align="center">
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/YUUCtljdrQw?si=d3DYaSUfiVyNgryj" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</p>
+
+## Our Mission
+
+OpenDI's mission is to empower you to make informed choices in a world that is increasingly volatile, uncertain, complex, and ambiguous.
+
+OpenDI.org is an integrated ecosystem that creates standards for Decision Intelligence. We curate a source of truth for how Decision Intelligence software systems interact, thereby allowing small and large participants alike to provide parts of an overall solution. By uniting decision makers, architects, asset managers, simulation managers, administrators, engineers, and researchers around a common framework, connecting technology to actions that lead to outcomes, we are paving the way for diverse contributors to solve local and global challenges, and to lower barriesr to entry for all Decision Intelligence stakeholders.
+
+[Learn More >>](./OpenDI%20Intro%20Material.md)
+
+## Our Motivation
 
 For two thousand years, humanity has created separate disciplines: economics, data science, artificial intelligence, medicine, computer science, complex systems analysis, psychology, and hundreds more.  Solutions to our greatest problems require that we move from these *specializations* and *knowledge silos* of our history to a fundamentally new *integration* that connects *knowledge* to *science* to *actions* to achieve *outcomes*. 
 
-Why? Because the greatest problems of our time &mdash; be they inequality, climate, conflict, or how your business can best succeed &mdash; can only be solved by understanding how decisions in one realm affect another, and by using the power of data to see further than ever before, along with AI to analzye that data. 
+Why? Because the greatest problems of our time &mdash; be they inequality, climate, conflict, or how your business can best succeed &mdash; can only be solved by understanding how decisions in one realm affect another, and by using the power of data to see further than ever before, and the power of AI to analzye that data. 
 
 But connecting the disciplines isn't enough. They also have to be connected to the *decisions* made by *people* whose consequences have effects near and far. 
 
 The OpenDI ecosystem &mdash; which is centered around the discipline of *Decision Intelligence* (which gives a blueprint for how to fit the pieces together) is the catalyst for this integration. 
-We're on a mission to empower you to make informed choices in a world that is increasingly volatile, uncertain, complex, and ambiguous.
-
-## What
-
-OpenDI.org is an integrated ecosystem whose mission includes creating standards for Decision Intelligence. We curate a source of truth 
-for how Decision Intelligence software systems interact, thereby allowing small and large participants alike to provide parts of an overall solution.
-By uniting decision makers, architects, asset managers, simulation managers, administrators, engineers, and researchers around a common framework that connects technology to actions that lead to outcomes, we are paving the way for diverse contributors to solve local and global challenges, and to lower barriers to entry for all Decision Intelligence stakeholders.
-
-[Learn More >>](./OpenDI%20Intro%20Material.md)
 
 ## OpenDI Standards
 OpenDI is a brand-new initiative, and this is reflected by our small set of initial standards drafts.  You can read them by following the links below.
@@ -59,5 +62,13 @@ Join the OpenDI Discord community!
 <iframe src="https://discord.com/widget?id=1208154608984129557&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
 
 ## Credits
-David Roberts, Lorien Pratt, Nadine Malcolm, Isaac Kellogg.  
+
+### Contributors
+David Roberts, Lorien Pratt, Nadine Malcolm, Isaac Kellogg.
+
 Add your name here! [Here's how.](./How%20To%20Contribute.md)
+
+### OpenDI Ambassadors
+Kaan Zaimoglu
+
+Interested in becoming an OpenDI Ambassador? Ask about it on the [OpenDI Discord community](https://discord.gg/FtAX3JStJz)!

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "3.5.2",
         "@docusaurus/preset-classic": "3.5.2",
-        "@mdx-js/react": "^3.0.0",
+        "@mdx-js/react": "^3.1.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.4.0",
         "react": "^18.0.0",
@@ -2960,9 +2960,9 @@
       }
     },
     "node_modules/@mdx-js/react": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.0.1.tgz",
-      "integrity": "sha512-9ZrPIU4MGf6et1m1ov3zKf+q9+deetI51zprKB1D/z3NOb+rUxxtEl3mCjW5wTGh6VhRdwPueh1oRzi6ezkA8A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
+      "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "3.5.2",
     "@docusaurus/preset-classic": "3.5.2",
-    "@mdx-js/react": "^3.0.0",
+    "@mdx-js/react": "^3.1.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.4.0",
     "react": "^18.0.0",

--- a/versioned_docs/version-Live/index.md
+++ b/versioned_docs/version-Live/index.md
@@ -10,24 +10,27 @@ Please consider [contributing](./How%20To%20Contribute.md), and joining the [Ope
 
 We are a decentralized group of entrepreneurs, executives, researchers, government leaders, and educators working to build an inclusive Decision Intelligence (DI) ecosystem dedicated to driving technological innovation, collaboration, and advancements in human decision making. Our goal is simple: *to break down the barriers that hinder progress and create a more open and integrated platform for Decision Intelligence technologies and services.*
 
-## Why
+<p align="center">
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/YUUCtljdrQw?si=d3DYaSUfiVyNgryj" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</p>
+
+## Our Mission
+
+OpenDI's mission is to empower you to make informed choices in a world that is increasingly volatile, uncertain, complex, and ambiguous.
+
+OpenDI.org is an integrated ecosystem that creates standards for Decision Intelligence. We curate a source of truth for how Decision Intelligence software systems interact, thereby allowing small and large participants alike to provide parts of an overall solution. By uniting decision makers, architects, asset managers, simulation managers, administrators, engineers, and researchers around a common framework, connecting technology to actions that lead to outcomes, we are paving the way for diverse contributors to solve local and global challenges, and to lower barriesr to entry for all Decision Intelligence stakeholders.
+
+[Learn More >>](./OpenDI%20Intro%20Material.md)
+
+## Our Motivation
 
 For two thousand years, humanity has created separate disciplines: economics, data science, artificial intelligence, medicine, computer science, complex systems analysis, psychology, and hundreds more.  Solutions to our greatest problems require that we move from these *specializations* and *knowledge silos* of our history to a fundamentally new *integration* that connects *knowledge* to *science* to *actions* to achieve *outcomes*. 
 
-Why? Because the greatest problems of our time &mdash; be they inequality, climate, conflict, or how your business can best succeed &mdash; can only be solved by understanding how decisions in one realm affect another, and by using the power of data to see further than ever before, along with AI to analzye that data. 
+Why? Because the greatest problems of our time &mdash; be they inequality, climate, conflict, or how your business can best succeed &mdash; can only be solved by understanding how decisions in one realm affect another, and by using the power of data to see further than ever before, and the power of AI to analzye that data. 
 
 But connecting the disciplines isn't enough. They also have to be connected to the *decisions* made by *people* whose consequences have effects near and far. 
 
 The OpenDI ecosystem &mdash; which is centered around the discipline of *Decision Intelligence* (which gives a blueprint for how to fit the pieces together) is the catalyst for this integration. 
-We're on a mission to empower you to make informed choices in a world that is increasingly volatile, uncertain, complex, and ambiguous.
-
-## What
-
-OpenDI.org is an integrated ecosystem whose mission includes creating standards for Decision Intelligence. We curate a source of truth 
-for how Decision Intelligence software systems interact, thereby allowing small and large participants alike to provide parts of an overall solution.
-By uniting decision makers, architects, asset managers, simulation managers, administrators, engineers, and researchers around a common framework that connects technology to actions that lead to outcomes, we are paving the way for diverse contributors to solve local and global challenges, and to lower barriers to entry for all Decision Intelligence stakeholders.
-
-[Learn More >>](./OpenDI%20Intro%20Material.md)
 
 ## OpenDI Standards
 OpenDI is a brand-new initiative, and this is reflected by our small set of initial standards drafts.  You can read them by following the links below.
@@ -59,5 +62,13 @@ Join the OpenDI Discord community!
 <iframe src="https://discord.com/widget?id=1208154608984129557&theme=dark" width="350" height="500" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
 
 ## Credits
-David Roberts, Lorien Pratt, Nadine Malcolm, Isaac Kellogg.  
+
+### Contributors
+David Roberts, Lorien Pratt, Nadine Malcolm, Isaac Kellogg.
+
 Add your name here! [Here's how.](./How%20To%20Contribute.md)
+
+### OpenDI Ambassadors
+Kaan Zaimoglu
+
+Interested in becoming an OpenDI Ambassador? Ask about it on the [OpenDI Discord community](https://discord.gg/FtAX3JStJz)!


### PR DESCRIPTION
- Added a list of OpenDI ambassadors to bottom of page, with currently-vague call to join Discord if interested

- Embedded an OpenDI intro video. This was adapted from a live recording of a presentation given by Dr. Roberts on a zoom meeting
    - There wasn't an obvious place to put this in the existing page, so I rearranged content and changed wording for better presentation in the new ordering.
    - Re-titled some sections. Aiming to convey more motivation.

[Dev preview is publicly viewable here.](https://opendi.org/next/)

Note: Suggest viewing content diffs in the "Split" view here on GitHub. Since content was moved around, unified diffs are a bit harder to parse.

----

Also bumped React to the next minor version, per Dependabot. I pulled these changes and ensured that the site still built locally. No issues found.