### PR TITLE
Enable Microsoft Clarity analytics with header code

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,6 +35,29 @@ const config = {
     locales: ['en'],
   },
 
+  // Adds Microsoft Clarity install code to the header for every page on the site.
+  // Note: For privacy/tracking reasons, we have our Clarity project configured to not save cookies
+  headTags: [
+    {
+      tagName: "link",
+      attributes: {
+        rel: "preconnect",
+        href: "https://www.clarity.ms",
+      },
+    },
+    {
+      tagName: "script",
+      attributes: {
+        type: "text/javascript"
+      },
+      innerHTML: `(function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "otc9atffo4");`,
+    },
+  ],
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
Added new headTag entry to Docusaurus config. This will generate code that goes in the header of each page. The headTag will generate a <script> tag containing the install code for Microsoft Clarity. This effectively performs the "manual" install instructions for Clarity, seen here https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-setup#install-manually

The Clarity project will be viewable here https://clarity.microsoft.com/projects/view/otc9atffo4/ The project is private, but we will be adding relevant team members soon.

Sites associated with all OpenDI repositories will share the same Clarity project, to make things simpler on the Clarity project management side of things.


Because this is a configuration change, there is no live preview for this change. Instead, I've tested an equivalent change on a private repo elsewhere, where it worked fine. If it somehow breaks here, our GitHub Actions pipeline should just fail to deploy it in the worst case.